### PR TITLE
[FIX] 게시글 업로드, 저장 문제 해결

### DIFF
--- a/src/main/java/com/hamlsy/springForum/controller/PostController.java
+++ b/src/main/java/com/hamlsy/springForum/controller/PostController.java
@@ -5,6 +5,7 @@ import com.hamlsy.springForum.dto.request.post.PostUploadRequest;
 import com.hamlsy.springForum.dto.response.post.PostListResponse;
 import com.hamlsy.springForum.dto.response.post.PostResponse;
 import com.hamlsy.springForum.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,7 +44,7 @@ public class PostController {
     }
 
     @PostMapping("/upload")
-    public String postUpload(PostUploadRequest dto, Principal principal){
+    public String postUpload(@Valid PostUploadRequest dto, Principal principal){
         postService.uploadPost(dto, principal);
         return "redirect:/post/list(page=0)";
     }

--- a/src/main/java/com/hamlsy/springForum/controller/PostController.java
+++ b/src/main/java/com/hamlsy/springForum/controller/PostController.java
@@ -46,7 +46,7 @@ public class PostController {
     @PostMapping("/upload")
     public String postUpload(@Valid PostUploadRequest dto, Principal principal){
         postService.uploadPost(dto, principal);
-        return "redirect:/post/list(page=0)";
+        return "redirect:/post/list?page=0";
     }
 
     @GetMapping("/{id}")

--- a/src/main/resources/templates/post_upload.html
+++ b/src/main/resources/templates/post_upload.html
@@ -7,7 +7,7 @@
 <div>
     <h5 class="my-3 border-bottom pb-2">게시글 등록</h5>
     <form th:action="@{/post/upload}" th:object="${postResponse}" method="post">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}" />
         <div class="mb-3">
             <label for="subject" class="form-label">제목</label>
             <input type="text" name="subject" id="subject" class="form-control">


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/8 -> main

### 변경 사항
게시글 업로드, 저장할 때 발생하는 에러를 해결했습니다.
csrf 토큰이 null로 전달될 때 발생하는 문제를 null 검사 후 값이 있을 때만 보여주게 했습니다.
Controller의 redirect 리턴 값의 "(page=0)"을 "?page=0"으로 변경했습니다.

### 테스트 결과


![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/bbb4ecf1-7112-4c84-929a-ec89cd66a386)
업로드 화면

![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/039dd544-fa1f-4563-bbba-267c1137e01f)
게시글 저장 후 화면

### 코멘트

단순 타임리프 문법 문제라고 생각했으나 스프링 시큐리티+csrf토큰 문제임을 보고 공부할 게 많다고 생각했습니다. csrf토큰과 시큐리티에 대해 완벽하게 이해하지 못한 상태로 수정한 거라, 추가적인 공부가 필요함을 느꼈습니다.
