### PR TITLE
[FIX] 게시글 수정 등록 오류 수정, 수정 시 내용 유지

### DIFF
--- a/src/main/java/com/hamlsy/springForum/controller/PostController.java
+++ b/src/main/java/com/hamlsy/springForum/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.hamlsy.springForum.controller;
 
+import com.hamlsy.springForum.dto.request.post.PostRequest;
 import com.hamlsy.springForum.dto.request.post.PostUpdateRequest;
 import com.hamlsy.springForum.dto.request.post.PostUploadRequest;
 import com.hamlsy.springForum.dto.response.post.PostListResponse;
@@ -39,7 +40,8 @@ public class PostController {
     }
 
     @GetMapping("/upload")
-    public String postUpload(){
+    public String postUpload(Model model){
+        model.addAttribute("postResponse", new PostResponse());
         return "post_upload";
     }
 

--- a/src/main/resources/templates/post_upload.html
+++ b/src/main/resources/templates/post_upload.html
@@ -6,15 +6,15 @@
 <nav th:replace="~{navbar :: navbarFragment}"></nav>
 <div>
     <h5 class="my-3 border-bottom pb-2">게시글 등록</h5>
-    <form th:action="@{/post/upload}" th:object="${postResponse}" method="post">
+    <form th:object="${postResponse}" method="post">
         <input type="hidden" th:name="${_csrf?.parameterName}" th:value="${_csrf?.token}" />
         <div class="mb-3">
             <label for="subject" class="form-label">제목</label>
-            <input type="text" name="subject" id="subject" class="form-control">
+            <input type="text" th:field="*{subject}" id="subject" class="form-control">
         </div>
         <div class="mb-3">
             <label for="content" class="form-label">내용</label>
-            <textarea name="content" id="content" class="form-control" rows="10"></textarea>
+            <textarea th:field="*{content}" id="content" class="form-control" rows="10"></textarea>
         </div>
         <input type="submit" value="저장하기" class="btn btn-primary my-2">
     </form>


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/10 -> main

### 변경 사항
게시글 수정할 때 기존 내용이 삭제되지 않습니다.
수정 후 등록할 때 새로운 게시글이 등록되는 오류를 수정했습니다.

### 테스트 결과

수정 전
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/b383eef5-4031-447e-9776-5e2bb2649e19)

수정 화면
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/faa365fd-85ba-4ae9-bbd7-c32933fea732)

수정 후
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/8f17393c-c87a-4aed-941a-b776ccfc6e94)

수정 후 게시글 목록
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/3bb19e00-69c2-4dd1-95ef-c2dae42f302c)

### 코멘트

 업로드 페이지와 수정 페이지를 하나로 사용하기 때문에 오류가 있었으나 의외로 간단하게 해결할 수 있었습니다.
 기존에는 form action 으로 저장버튼 누를 시 upload -> POST 가 강제됐었는데, 타임리프에서 form action을 지워주면 자동으로 해당 url 을 기준으로 전송됨을 알았습니다. 
 따라서 같은 템플릿을 사용하더라도 upload url로 보내냐, modify url로 보내냐에 따라 다르게 적용할 수 있었습니다.