### PR TITLE
[REFACTOR] 게시글 전체 조회 n+1 개선

### DIFF
--- a/src/main/java/com/hamlsy/springForum/dto/response/post/PostListResponse.java
+++ b/src/main/java/com/hamlsy/springForum/dto/response/post/PostListResponse.java
@@ -1,12 +1,12 @@
 package com.hamlsy.springForum.dto.response.post;
 
 import com.hamlsy.springForum.domain.Post;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.hamlsy.springForum.repository.PostRepository;
+import lombok.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter

--- a/src/main/java/com/hamlsy/springForum/repository/PostRepository.java
+++ b/src/main/java/com/hamlsy/springForum/repository/PostRepository.java
@@ -4,6 +4,7 @@ import com.hamlsy.springForum.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +12,7 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAll(Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN FETCH p.member")
+    Page<Post> findAllWithMember(Pageable pageable);
 }

--- a/src/main/java/com/hamlsy/springForum/service/PostService.java
+++ b/src/main/java/com/hamlsy/springForum/service/PostService.java
@@ -95,7 +95,7 @@ public class PostService {
     public Page<PostListResponse> paging(int page){
         int pageLimit = 15;
         Pageable pageable = PageRequest.of(page, pageLimit, Sort.by(Sort.Order.desc("postTime")));
-        Page<Post> postList = postRepository.findAll(pageable);
+        Page<Post> postList = postRepository.findAllWithMember(pageable);
         Page<PostListResponse> postPageList = postList.map(
                 postPage -> new PostListResponse().fromEntity(postPage)
         );


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/36 -> main

### 변경 사항
게시글 전체 조회 시 n+1 문제를 fetch join으로 해결했습니다.

### 테스트 결과

fetch join 적용 전 - 조회 쿼리 10개 이상
fetch join 적용 후 - 조회 쿼리 1개
```
select
        p1_0.post_id,
        p1_0.content,
        m1_0.member_id,
        m1_0.name,
        m1_0.nickname,
        m1_0.password,
        m1_0.role,
        m1_0.user_id,
        p1_0.modify_time,
        p1_0.post_time,
        p1_0.subject 
    from
        posts p1_0 
    join
        member m1_0 
            on m1_0.member_id=p1_0.member_id 
    order by
        p1_0.post_time desc 
    offset
        ? rows 
    fetch
        first ? rows only 
```

### 코멘트

 기존 코드에는 Post(게시물)를 불러올 때 Post에 속하는 Member(회원)를 하나씩 더 불러오는 n+1문제가 있었습니다. 

 원인은 Post를 불러오고 그 안의 프록시 객체 Member를 사용할 때 JPQL에서 쿼리를 한번 더 실행하는 곳에 있었습니다.

 따라서 JPA PostRepository 의 findAll 메서드를 fetch join을 사용하는 메서드로 변경하여, 처음 Post를 불러올 때 실 객체 Member도 같이 불러오게 합니다. 그렇게 하면 DTO 등에서 Member 객체를 사용할 때 JPQL에서 추가 쿼리를 실행하지 않기 때문에 성능 개선을 할 수 있었습니다.

 지연로딩, 페치조인에 대한 학습에 도움이 되었던 이슈였습니다.

