### PR TITLE
#38 [FEAT] 게시글 삭제 API, 인증 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,10 @@ out/
 ### vue ###
 ./vue-cli/node_modules
 
-
+###modules
+out
+node_modules
+.gradle
 
 
 

--- a/src/main/java/com/hamlsy/springForum/controller/PostController.java
+++ b/src/main/java/com/hamlsy/springForum/controller/PostController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -50,11 +51,12 @@ public class PostController {
         try{
             PostResponse response = postService.findPost(id);
             return new ResponseEntity<>(response, HttpStatus.OK);
-        }catch(NoSuchElementException e){
+        }catch(NullPointerException | NoSuchElementException e){
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         }
-
-
+        catch(Exception e){
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
     }
 
     @GetMapping("/update/{id}")
@@ -66,10 +68,13 @@ public class PostController {
             return new ResponseEntity<>(response, HttpStatus.OK);
         }
         catch(AccessDeniedException e){
-            return new ResponseEntity<>(null, HttpStatus.NOT_ACCEPTABLE);
+            return new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
         }
-        catch(NoSuchElementException e){
-            return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
+        catch(NullPointerException | NoSuchElementException e){
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }
+        catch(Exception e){
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -80,18 +85,31 @@ public class PostController {
             return new ResponseEntity<>(response, HttpStatus.OK);
         }
         catch(AccessDeniedException e){
-            return new ResponseEntity<>(null, HttpStatus.NOT_ACCEPTABLE);
+            return new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
+        }
+        catch(NullPointerException | NoSuchElementException e){
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         }
         catch(Exception e){
-            return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
 
     }
 
     @GetMapping("/delete/{id}")
-    public String postDelete(@PathVariable("id") Long postId, Principal principal){
-        postService.deletePost(postId, principal);
-        return "redirect:/post/list";
+    public ResponseEntity<?> postDelete(@PathVariable("id") Long postId){
+        try{
+            postService.deletePost(postId);
+            return new ResponseEntity<>(null, HttpStatus.OK);
+        }catch(AccessDeniedException e){
+            return new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
+        }catch(NullPointerException | NoSuchElementException e){
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        }catch(Exception e){
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+
+
     }
 
 }

--- a/src/main/java/com/hamlsy/springForum/init/InitDb.java
+++ b/src/main/java/com/hamlsy/springForum/init/InitDb.java
@@ -20,10 +20,10 @@ public class InitDb {
 
     @PostConstruct
     public void init(){
-        initService.dbInit1();
+//        initService.dbInit1();
 //        initService.dbInit2();
 
-        initService.dbInitLoop(40);
+//        initService.dbInitLoop(40);
 
     }
 

--- a/src/main/java/com/hamlsy/springForum/service/PostService.java
+++ b/src/main/java/com/hamlsy/springForum/service/PostService.java
@@ -54,14 +54,9 @@ public class PostService {
     }
 
     @Transactional
-    public void deletePost(Long postId, Principal principal){
-        if(principal == null){
-            throw new IllegalStateException("인증이 필요합니다.");
-        }
+    public void deletePost(Long postId) throws AccessDeniedException, NullPointerException, NoSuchElementException{
         Post post = findPostById(postId);
-        if(post.getMember().getUserId() != principal.getName()){
-            throw new IllegalStateException("작성자만 삭제할 수 있습니다.");
-        }
+        memberValidation(post.getMember().getUserId());
         postRepository.deleteById(postId);
     }
 
@@ -87,8 +82,7 @@ public class PostService {
 
     private Post findPostById(Long id){
         return postRepository.findById(id).orElseThrow(
-                //todo: 예외 클래스 새로 작성
-                () -> new NoSuchElementException()
+                () -> new NullPointerException()
         );
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true

--- a/vue-cli/src/components/PostDetail.vue
+++ b/vue-cli/src/components/PostDetail.vue
@@ -52,6 +52,7 @@ export default {
         content: ''
       },
       newComment: '',
+      token: localStorage.getItem('member'),
     };
   },
   created() {
@@ -77,10 +78,37 @@ export default {
       window.location.href = "/post/update/" + this.post.postId;
     },
     deletePost() {
-      // 게시글 삭제 로직 추가
+      const headers = {
+        'Authorization': this.token
+      }
+      if(confirm("삭제하시겠습니까?")) {
+        axios.get("/post/delete/" + this.$route.params.id, {headers})
+            .then((res) => {
+              alert("게시글이 삭제되었습니다.");
+              console.log("게시글이 삭제되었습니다.", res);
+              window.location.href = "/post/list";
+            })
+            .catch((error) => {
+              if(error.response.status === 404){
+                alert("게시글이 존재하지 않습니다.");
+                console.log("게시글이 존재하지 않습니다.", error);
+              }
+              else if(error.response.status === 403){
+                alert("잘못된 접근입니다.");
+                console.log("잘못된 접근입니다.", error);
+              }
+              else{
+                alert("알 수 없는 오류가 발생했습니다.");
+                console.log("알 수 없는 오류", error);
+              }
+          })
+      }
+
+
       console.log('게시글 삭제');
     },
     addComment() {
+
       // 댓글 등록 로직 추가
       console.log('댓글 등록:', this.newComment);
       this.newComment = '';


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/38 -> main

### 변경 사항
게시글 삭제 기능을 구현했습니다. 삭제 시 인증도 구현했습니다.
작성한 게시글만 삭제 가능하며, 익명이거나 다른 게시물의 경우 삭제를 할 수 없습니다.

### 테스트 결과

작성한 게시글 삭제
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/4e429509-7987-40cf-90a2-29d9461ed0e6)
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/580e5b5d-d08a-4ee6-bc4a-9366efaa211d)
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/fb56a1d8-53f5-48ea-a1c6-1999173d7bb9)
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/613fd258-e6ca-4916-9a68-53dbe025cb6c)

작성하지 않은 게시글 삭제 접근
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/e9e28161-0b5f-4059-b9f7-af5c0b6f7742)
![image](https://github.com/hamlsy/forum-springBoot/assets/70877744/285cef24-0b1b-4de6-9f8c-adabf45d2721)


### 코멘트

예외 구현 중에 Optional 에 orElseThrow로 NullPointerException 을 반환하게 했지만,
findById 메서드가 Optional 안에서 돌아가면 isPresent 로 NoSuchElementException 이 발생한다는 것을 알았습니다.

다음부터는 정확한 예외 분리와 상태코드에 따른 분기를 구현하도록 하겠습니다.

